### PR TITLE
build: configure am-lib as submodule

### DIFF
--- a/am-lib/build.gradle
+++ b/am-lib/build.gradle
@@ -8,12 +8,11 @@ group 'uk.gov.hmcts.reform'
 version "${version}"
 
 apply plugin: 'java-library'
-//apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'checkstyle'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'jacoco'
-apply plugin: 'com.github.ben-manes.versions'
+
 apply plugin: 'pmd'
 
 configurations {
@@ -63,26 +62,6 @@ dependencies {
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.197'
     testCompile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
-}
-
-dependencyUpdates.resolutionStrategy = {
-    componentSelection { rules ->
-        rules.all { ComponentSelection selection ->
-            boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
-                selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
-            }
-            if (rejected) {
-                selection.reject('Release candidate')
-            }
-        }
-    }
-}
-
-dependencyCheck {
-    // Specifies if the build should be failed if a CVSS score above a specified level is identified.
-    // range of 0-10 fails the build, anything greater and it doesn't fail the build
-    failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
-    suppressionFile = "$rootDir/config/owasp/suppressions.xml"
 }
 
 task codeCoverageReport(type: JacocoReport, dependsOn: test) {

--- a/am-lib/build.gradle
+++ b/am-lib/build.gradle
@@ -1,6 +1,4 @@
 plugins {
-    id 'org.owasp.dependencycheck' version '4.0.2'
-    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'info.solidsoft.pitest' version '1.4.0'
@@ -9,9 +7,8 @@ plugins {
 group 'uk.gov.hmcts.reform'
 version "${version}"
 
-apply plugin: 'java'
 apply plugin: 'java-library'
-apply plugin: 'maven'
+//apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'checkstyle'
 apply plugin: 'com.jfrog.bintray'

--- a/am-lib/build.gradle
+++ b/am-lib/build.gradle
@@ -1,4 +1,9 @@
 plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'checkstyle'
+    id 'pmd'
+    id 'jacoco'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'info.solidsoft.pitest' version '1.4.0'
@@ -6,14 +11,6 @@ plugins {
 
 group 'uk.gov.hmcts.reform'
 version "${version}"
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
-apply plugin: 'checkstyle'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'jacoco'
-
-apply plugin: 'pmd'
 
 configurations {
     testOutput.extendsFrom(testCompile)

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ plugins {
 }
 
 subprojects {
-    apply plugin: 'com.github.ben-manes.versions'
     apply plugin: 'org.owasp.dependencycheck'
+    apply plugin: 'com.github.ben-manes.versions'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ plugins {
     id "org.flywaydb.flyway" version "5.2.4"
 }
 
+subprojects {
+    apply plugin: 'com.github.ben-manes.versions'
+    apply plugin: 'org.owasp.dependencycheck'
+}
+
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'pmd'
-    id 'java'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'org.springframework.boot' version '2.1.2.RELEASE'
@@ -15,13 +14,8 @@ plugins {
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'
 
-def amLibJarVersion = '0.0.8'
-def amLibJarName = "am-lib-${amLibJarVersion}-all.jar"
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-
-apply plugin: 'java'
 
 sourceSets {
     test {
@@ -159,12 +153,12 @@ def versions = [
 ]
 
 dependencies {
+    compile project(':am-lib')
+
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
-    compile files(amLibJarName)
-    testCompile files(amLibJarName)
 
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
@@ -196,29 +190,10 @@ bootJar {
     }
 }
 
-task testLib(type: Exec) {
-    workingDir './am-lib'
-    commandLine './gradlew', 'test'
-}
-
 task pitest(type: Exec) {
     workingDir './am-lib'
     commandLine './gradlew', 'pitest', '--rerun-tasks'
 }
-
-task buildLib(type: Exec) {
-    workingDir './am-lib'
-    commandLine './gradlew', 'build', 'shadowJar'
-}
-
-task copyLib(type: Exec) {
-    workingDir '.'
-    commandLine 'cp', "./am-lib/build/libs/${amLibJarName}", '.'
-}
-
-test.dependsOn testLib
-compileJava.dependsOn copyLib
-copyLib.dependsOn buildLib
 
 //local flyway settings
 flyway {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'am-lib-testing-service'
+
+include 'am-lib'


### PR DESCRIPTION
Having library defined as submodule of main project will make service development easier.
This way IDE will have ability to jump directly to right library sources when referenced from REST service.