### PR TITLE
refactor: use immutable collections

### DIFF
--- a/am-lib/build.gradle
+++ b/am-lib/build.gradle
@@ -62,12 +62,16 @@ dependencies {
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
 
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     compile group: 'org.jdbi', name: 'jdbi3-core', version: '3.6.0'
     compile group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.6.0'
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
+    compile (group: 'com.google.guava', name: 'guava', version: '27.0.1-jre') {
+      transitive false
+    }
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.4.0'
+    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.24.5'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.0'
     testCompile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
@@ -106,6 +110,10 @@ task jarTest(type: Jar, dependsOn: testClasses) {
 shadowJar {
     from('src/main/java') {
         include '**/*.sql'
+    }
+    relocate 'com.google', 'shadow.com.google'
+    minimize {
+      exclude(dependency('org.postgresql:.*:.*'))
     }
     archiveClassifier = 'all'
 }

--- a/am-lib/build.gradle
+++ b/am-lib/build.gradle
@@ -62,16 +62,15 @@ dependencies {
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
 
-    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     compile group: 'org.jdbi', name: 'jdbi3-core', version: '3.6.0'
     compile group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.6.0'
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     compile (group: 'com.google.guava', name: 'guava', version: '27.0.1-jre') {
       transitive false
     }
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.4.0'
-    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.24.5'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.0'
     testCompile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'

--- a/am-lib/lombok.config
+++ b/am-lib/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling=true
+lombok.singular.useGuava=true

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
@@ -111,9 +111,9 @@ public class AccessManagementService {
         }
 
         if (READ.isGranted(explicitAccess.getPermissions())) {
-            Map<JsonPointer, Set<Permission>> permissions = ImmutableMap.<JsonPointer, Set<Permission>>builder()
-                .put(JsonPointer.valueOf(""), Permissions.fromSumOf(explicitAccess.getPermissions()))
-                .build();
+            Map<JsonPointer, Set<Permission>> permissions = ImmutableMap.of(
+                JsonPointer.valueOf(""), Permissions.fromSumOf(explicitAccess.getPermissions())
+            );
 
             return FilterResourceResponse.builder()
                 .resourceId(resourceId)

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessGrant.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessGrant.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Singular;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 
 import java.util.Map;
@@ -20,6 +21,6 @@ public class ExplicitAccessGrant {
     private final String serviceName;
     private final String resourceType;
     private final String resourceName;
-    private final Map<JsonPointer, Set<Permission>> attributePermissions;
+    @Singular private final Map<JsonPointer, Set<Permission>> attributePermissions;
     private final String securityClassification;
 }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.amlib.models;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Singular;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.utils.Permissions;
@@ -25,7 +26,7 @@ public final class ExplicitAccessRecord extends AbstractAccessMetadata {
                                  String resourceName,
                                  String attribute,
                                  String securityClassification,
-                                 Set<Permission> explicitPermissions) {
+                                 @Singular Set<Permission> explicitPermissions) {
         super(resourceId, accessorId, accessType, serviceName, resourceType, resourceName, attribute,
             securityClassification);
         this.explicitPermissions = explicitPermissions;

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/FilterResourceResponse.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/FilterResourceResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Singular;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 
 import java.util.Map;
@@ -14,5 +15,5 @@ import java.util.Set;
 public class FilterResourceResponse {
     private String resourceId;
     private JsonNode data;
-    private Map<JsonPointer, Set<Permission>> permissions;
+    @Singular private Map<JsonPointer, Set<Permission>> permissions;
 }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/utils/Permissions.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/utils/Permissions.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.amlib.utils;
 
+import com.google.common.collect.ImmutableSet;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.exceptions.UnsupportedPermissionsException;
 
@@ -61,6 +62,6 @@ public final class Permissions {
 
         return Arrays.stream(Permission.values())
             .filter(permission -> permission.isGranted(sumOfPermissions))
-            .collect(Collectors.toSet());
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/utils/Permissions.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/utils/Permissions.java
@@ -6,8 +6,6 @@ import uk.gov.hmcts.reform.amlib.exceptions.UnsupportedPermissionsException;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static uk.gov.hmcts.reform.amlib.enums.Permission.CREATE;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.DELETE;
@@ -32,7 +30,7 @@ public final class Permissions {
      * @see Permissions#sumOf(Set)
      */
     public static int sumOf(Permission... permissions) {
-        return sumOf(Stream.of(permissions).collect(Collectors.toSet()));
+        return sumOf(ImmutableSet.copyOf(permissions));
     }
 
     /**

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
@@ -1,16 +1,16 @@
 package integration.uk.gov.hmcts.reform.amlib;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import integration.uk.gov.hmcts.reform.amlib.base.IntegrationBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -32,17 +32,17 @@ class GrantAccessIntegrationTest extends IntegrationBaseTest {
 
     @Test
     void noAttributesShouldThrowException() {
-        Map<JsonPointer, Set<Permission>> emptyAttributePermissions = new ConcurrentHashMap<>();
+        Map<JsonPointer, Set<Permission>> noAttributes = ImmutableMap.of();
 
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
-            ams.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, emptyAttributePermissions)))
+            ams.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, noAttributes)))
             .withMessage("At least one attribute is required");
     }
 
     @Test
     @SuppressWarnings("PMD")
     void noPermissionsForAttributesShouldThrowException() {
-        Map<JsonPointer, Set<Permission>> attributeNoPermissions = createPermissionsForWholeDocument(new HashSet<>());
+        Map<JsonPointer, Set<Permission>> attributeNoPermissions = createPermissionsForWholeDocument(ImmutableSet.of());
 
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
             ams.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, attributeNoPermissions)))
@@ -58,11 +58,12 @@ class GrantAccessIntegrationTest extends IntegrationBaseTest {
 
     @Test
     void whenCreatingResourceAccessMultipleEntriesAppearInDatabase() {
-        Map<JsonPointer, Set<Permission>> multipleAttributePermissions = new ConcurrentHashMap<>();
-        multipleAttributePermissions.put(JsonPointer.valueOf(""), EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS);
-        multipleAttributePermissions.put(JsonPointer.valueOf("/name"), EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS);
+        Map<JsonPointer, Set<Permission>> multipleAttributes = ImmutableMap.<JsonPointer, Set<Permission>>builder()
+            .put(JsonPointer.valueOf(""), EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS)
+            .put(JsonPointer.valueOf("/name"), EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS)
+            .build();
 
-        ams.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, multipleAttributePermissions));
+        ams.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, multipleAttributes));
 
         assertThat(countResourcesById(resourceId)).isEqualTo(2);
     }

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/PermissionTest.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/PermissionTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.amlib;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -7,10 +8,7 @@ import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.exceptions.UnsupportedPermissionsException;
 import uk.gov.hmcts.reform.amlib.utils.Permissions;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -38,14 +36,14 @@ class PermissionTest {
 
     @Test
     void sumOf_shouldCalculateSumOfPermissionsFromEmptySet() {
-        int sumOfPermissions = Permissions.sumOf(new HashSet<>());
+        int sumOfPermissions = Permissions.sumOf(ImmutableSet.of());
         assertThat(sumOfPermissions).isEqualTo(0);
     }
 
     @ParameterizedTest
     @MethodSource("createArguments")
     void sumOf_shouldCalculateSumOfPermissionsFromSet(Arguments args) {
-        int sumOfPermissions = Permissions.sumOf(Arrays.stream(args.permissions).collect(Collectors.toSet()));
+        int sumOfPermissions = Permissions.sumOf(ImmutableSet.copyOf(args.permissions));
         assertThat(sumOfPermissions).isEqualTo(args.sumOfPermissions);
     }
 

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
@@ -2,12 +2,11 @@ package uk.gov.hmcts.reform.amlib.helpers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.collect.ImmutableSet;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toSet;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.CREATE;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.READ;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.UPDATE;
@@ -21,10 +20,9 @@ public final class TestConstants {
     public static final String SECURITY_CLASSIFICATION = "Public";
     public static final String ACCESSOR_ID = "a";
     public static final String OTHER_ACCESSOR_ID = "b";
-    public static final Set<Permission> EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS =
-        Stream.of(CREATE, READ, UPDATE).collect(toSet());
-    public static final Set<Permission> CREATE_PERMISSION = Stream.of(CREATE).collect(toSet());
-    public static final Set<Permission> READ_PERMISSION = Stream.of(READ).collect(toSet());
+    public static final Set<Permission> EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS = ImmutableSet.of(CREATE, READ, UPDATE);
+    public static final Set<Permission> CREATE_PERMISSION = ImmutableSet.of(CREATE);
+    public static final Set<Permission> READ_PERMISSION = ImmutableSet.of(READ);
     public static final JsonNode DATA = JsonNodeFactory.instance.objectNode();
 
     private TestConstants() {

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.reform.amlib.helpers;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.google.common.collect.ImmutableMap;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessGrant;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessMetadata;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESS_TYPE;
@@ -54,9 +54,7 @@ public final class TestDataFactory {
 
     public static Map<JsonPointer, Set<Permission>> createPermissions(String attribute,
                                                                       Set<Permission> permissions) {
-        Map<JsonPointer, Set<Permission>> attributePermissions = new ConcurrentHashMap<>();
-        attributePermissions.put(JsonPointer.valueOf(attribute), permissions);
-        return attributePermissions;
+        return ImmutableMap.of(JsonPointer.valueOf(attribute), permissions);
     }
 
     public static ExplicitAccessMetadata createMetadata(String resourceId) {

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ def versions = [
 ]
 
 dependencies {
-    compile project(':am-lib')
+    compile project(path: ':am-lib', configuration: 'shadow')
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Mutable collections were replaced with Google immutable implementations.

To avoid conflicts with older Guava versions (especially older then v16.0) shadowing is used.

To reduce size of the fat-jar shadow plugin was configured to remove unused classes.

### Checklist ###

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org) approach and uses one of the following types:
    - build: changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    - ci: changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    - docs: documentation only changes
    - feat: a new feature
    - fix: a bug fix
    - perf: a code change that improves performance
    - refactor: a code change that neither fixes a bug nor adds a feature
    - style: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    - test: adding missing tests or correcting existing tests
- [ ] commit messages are meaningful and follow good commit message guidelines to ease review process
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
