### PR TITLE
refactor: remove JDBI constructors

### DIFF
--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/DefaultRoleSetupImportService.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/DefaultRoleSetupImportService.java
@@ -124,7 +124,7 @@ public class DefaultRoleSetupImportService {
                         .resourceName(defaultPermissionGrant.getResourceName())
                         .resourceType(defaultPermissionGrant.getResourceType())
                         .attribute(attribute)
-                        .securityClassification(permissionAndClassification.getValue())
+                        .defaultSecurityClassification(permissionAndClassification.getValue())
                         .build()
                     );
 

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/AbstractAccessMetadata.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/AbstractAccessMetadata.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 @Data
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,5 +18,5 @@ public abstract class AbstractAccessMetadata {
     private final String resourceType;
     private final String resourceName;
     private final JsonPointer attribute;
-    private final String securityClassification;
+    private final SecurityClassification securityClassification;
 }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessGrant.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessGrant.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 import java.util.Map;
 import java.util.Set;
@@ -21,5 +22,5 @@ public class ExplicitAccessGrant {
     private final String resourceType;
     private final String resourceName;
     private final Map<JsonPointer, Set<Permission>> attributePermissions;
-    private final String securityClassification;
+    private final SecurityClassification securityClassification;
 }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessMetadata.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessMetadata.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -19,7 +20,7 @@ public final class ExplicitAccessMetadata extends AbstractAccessMetadata {
                                    String resourceType,
                                    String resourceName,
                                    JsonPointer attribute,
-                                   String securityClassification) {
+                                   SecurityClassification securityClassification) {
         super(resourceId, accessorId, accessType, serviceName, resourceType, resourceName, attribute,
             securityClassification);
     }

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.utils.Permissions;
 
@@ -18,33 +17,18 @@ public final class ExplicitAccessRecord extends AbstractAccessMetadata implement
 
     @Builder // All args constructor is needed for builder. @SuperBuilder cannot be used because IDE does not support it
     @SuppressWarnings("squid:S00107") // Having so many arguments seems reasonable solution here
-    private ExplicitAccessRecord(String resourceId,
-                                 String accessorId,
-                                 String accessType,
-                                 String serviceName,
-                                 String resourceType,
-                                 String resourceName,
-                                 JsonPointer attribute,
-                                 Set<Permission> permissions,
-                                 String securityClassification) {
-        super(resourceId, accessorId, accessType, serviceName, resourceType, resourceName, attribute,
-            securityClassification);
-        this.permissions = permissions;
-    }
-
-    @JdbiConstructor
-    @SuppressWarnings("squid:S00107") // Having so many arguments seems reasonable solution here
     public ExplicitAccessRecord(String resourceId,
                                 String accessorId,
                                 String accessType,
                                 String serviceName,
                                 String resourceType,
                                 String resourceName,
-                                String attribute,
-                                int permissions,
+                                JsonPointer attribute,
+                                Set<Permission> permissions,
                                 String securityClassification) {
-        this(resourceId, accessorId, accessType, serviceName, resourceType, resourceName,
-            JsonPointer.valueOf(attribute), Permissions.fromSumOf(permissions), securityClassification);
+        super(resourceId, accessorId, accessType, serviceName, resourceType, resourceName, attribute,
+            securityClassification);
+        this.permissions = permissions;
     }
 
     @Override

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessRecord.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 import uk.gov.hmcts.reform.amlib.utils.Permissions;
 
 import java.util.Set;
@@ -25,7 +26,7 @@ public final class ExplicitAccessRecord extends AbstractAccessMetadata implement
                                 String resourceName,
                                 JsonPointer attribute,
                                 Set<Permission> permissions,
-                                String securityClassification) {
+                                SecurityClassification securityClassification) {
         super(resourceId, accessorId, accessType, serviceName, resourceType, resourceName, attribute,
             securityClassification);
         this.permissions = permissions;

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ResourceAttribute.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ResourceAttribute.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 @Data
@@ -15,13 +14,7 @@ public class ResourceAttribute {
     private final String resourceType;
     private final String resourceName;
     private final JsonPointer attribute;
-    private final SecurityClassification securityClassification;
-
-    @JdbiConstructor
-    public ResourceAttribute(String serviceName, String resourceType, String resourceName, String attribute,
-                             SecurityClassification defaultSecurityClassification) {
-        this(serviceName, resourceType, resourceName, JsonPointer.valueOf(attribute), defaultSecurityClassification);
-    }
+    private final SecurityClassification defaultSecurityClassification;
 
     public String getAttributeAsString() {
         return attribute.toString();

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/RoleBasedAccessRecord.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/RoleBasedAccessRecord.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.utils.Permissions;
 
@@ -21,18 +20,6 @@ public final class RoleBasedAccessRecord implements AttributeAccessDefinition {
     private final String roleName;
     private final JsonPointer attribute;
     private final Set<Permission> permissions;
-
-    @JdbiConstructor
-    @SuppressWarnings("squid:S00107") // Having so many arguments seems reasonable solution here
-    public RoleBasedAccessRecord(String serviceName,
-                                 String resourceType,
-                                 String resourceName,
-                                 String roleName,
-                                 String attribute,
-                                 int permissions) {
-        this(serviceName, resourceType, resourceName, roleName, JsonPointer.valueOf(attribute),
-            Permissions.fromSumOf(permissions));
-    }
 
     @Override
     public String getAttributeAsString() {

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/AccessManagementRepository.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/AccessManagementRepository.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.amlib.repositories;
 
+import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
+import org.jdbi.v3.sqlobject.config.RegisterColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -8,10 +10,16 @@ import uk.gov.hmcts.reform.amlib.enums.AccessType;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessMetadata;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessRecord;
 import uk.gov.hmcts.reform.amlib.models.RoleBasedAccessRecord;
+import uk.gov.hmcts.reform.amlib.repositories.mappers.JsonPointerMapper;
+import uk.gov.hmcts.reform.amlib.repositories.mappers.PermissionSetMapper;
 
 import java.util.List;
 
 @SuppressWarnings("LineLength")
+@RegisterColumnMappers({
+    @RegisterColumnMapper(JsonPointerMapper.class),
+    @RegisterColumnMapper(PermissionSetMapper.class)
+})
 public interface AccessManagementRepository {
 
     @SqlUpdate("insert into access_management (resource_id, accessor_id, permissions, access_type, service_name, resource_type, resource_name, attribute, security_classification) "
@@ -29,7 +37,6 @@ public interface AccessManagementRepository {
         + "and access_management.resource_name = :resourceName "
         + "and access_management.attribute = :attributeAsString")
     void removeAccessManagementRecord(@BindBean ExplicitAccessMetadata explicitAccessMetadata);
-
 
     @SqlQuery("select accessor_id from access_management where exists "
         + "(select 1 from access_management where access_management.accessor_id = :accessorId "

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/AccessManagementRepository.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/AccessManagementRepository.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.amlib.repositories;
 
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
-import org.jdbi.v3.sqlobject.config.RegisterColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -16,10 +15,8 @@ import uk.gov.hmcts.reform.amlib.repositories.mappers.PermissionSetMapper;
 import java.util.List;
 
 @SuppressWarnings("LineLength")
-@RegisterColumnMappers({
-    @RegisterColumnMapper(JsonPointerMapper.class),
-    @RegisterColumnMapper(PermissionSetMapper.class)
-})
+@RegisterColumnMapper(JsonPointerMapper.class)
+@RegisterColumnMapper(PermissionSetMapper.class)
 public interface AccessManagementRepository {
 
     @SqlUpdate("insert into access_management (resource_id, accessor_id, permissions, access_type, service_name, resource_type, resource_name, attribute, security_classification) "

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/DefaultRoleSetupRepository.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/DefaultRoleSetupRepository.java
@@ -23,8 +23,8 @@ public interface DefaultRoleSetupRepository {
     void addResourceDefinition(String serviceName, String resourceType, String resourceName);
 
     @SqlUpdate("insert into resource_attributes (service_name, resource_type, resource_name, attribute, default_security_classification)"
-        + " values (:serviceName, :resourceType, :resourceName, :attributeAsString, cast(:securityClassification as security_classification))"
-        + " on conflict on constraint resource_attributes_pkey do update set default_security_classification = cast(:securityClassification as security_classification)")
+        + " values (:serviceName, :resourceType, :resourceName, :attributeAsString, cast(:defaultSecurityClassification as security_classification))"
+        + " on conflict on constraint resource_attributes_pkey do update set default_security_classification = cast(:defaultSecurityClassification as security_classification)")
     void createResourceAttribute(@BindBean ResourceAttribute resourceAttribute);
 
     @SqlUpdate("insert into default_permissions_for_roles (service_name, resource_type, resource_name, attribute, role_name, permissions)"

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/mappers/JsonPointerMapper.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/mappers/JsonPointerMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.amlib.repositories.mappers;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class JsonPointerMapper implements ColumnMapper<JsonPointer> {
+    @Override
+    public JsonPointer map(ResultSet resultSet, int columnNumber, StatementContext ctx) throws SQLException {
+        return resultSet.wasNull() ? null : JsonPointer.valueOf(resultSet.getString(columnNumber));
+    }
+
+    @Override
+    public JsonPointer map(ResultSet resultSet, String columnLabel, StatementContext ctx) throws SQLException {
+        return resultSet.wasNull() ? null : JsonPointer.valueOf(resultSet.getString(columnLabel));
+    }
+}

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/mappers/PermissionSetMapper.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/repositories/mappers/PermissionSetMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.amlib.repositories.mappers;
+
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.hmcts.reform.amlib.enums.Permission;
+import uk.gov.hmcts.reform.amlib.utils.Permissions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Set;
+
+public class PermissionSetMapper implements ColumnMapper<Set<Permission>> {
+    @Override
+    public Set<Permission> map(ResultSet resultSet, int columnNumber, StatementContext ctx) throws SQLException {
+        return resultSet.wasNull() ? null : Permissions.fromSumOf(resultSet.getInt(columnNumber));
+    }
+
+    @Override
+    public Set<Permission> map(ResultSet resultSet, String columnLabel, StatementContext ctx) throws SQLException {
+        return resultSet.wasNull() ? null : Permissions.fromSumOf(resultSet.getInt(columnLabel));
+    }
+}

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/helpers/DatabaseHelperRepository.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/helpers/DatabaseHelperRepository.java
@@ -1,5 +1,7 @@
 package integration.uk.gov.hmcts.reform.amlib.helpers;
 
+import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
+import org.jdbi.v3.sqlobject.config.RegisterColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -8,8 +10,14 @@ import uk.gov.hmcts.reform.amlib.models.ResourceAttribute;
 import uk.gov.hmcts.reform.amlib.models.ResourceDefinition;
 import uk.gov.hmcts.reform.amlib.models.Role;
 import uk.gov.hmcts.reform.amlib.models.Service;
+import uk.gov.hmcts.reform.amlib.repositories.mappers.JsonPointerMapper;
+import uk.gov.hmcts.reform.amlib.repositories.mappers.PermissionSetMapper;
 
 @SuppressWarnings({"PMD", "LineLength"})
+@RegisterColumnMappers({
+    @RegisterColumnMapper(JsonPointerMapper.class),
+    @RegisterColumnMapper(PermissionSetMapper.class)
+})
 public interface DatabaseHelperRepository {
 
     @SqlUpdate("delete from access_management;"

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/helpers/DatabaseHelperRepository.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/helpers/DatabaseHelperRepository.java
@@ -1,7 +1,6 @@
 package integration.uk.gov.hmcts.reform.amlib.helpers;
 
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
-import org.jdbi.v3.sqlobject.config.RegisterColumnMappers;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -14,10 +13,8 @@ import uk.gov.hmcts.reform.amlib.repositories.mappers.JsonPointerMapper;
 import uk.gov.hmcts.reform.amlib.repositories.mappers.PermissionSetMapper;
 
 @SuppressWarnings({"PMD", "LineLength"})
-@RegisterColumnMappers({
-    @RegisterColumnMapper(JsonPointerMapper.class),
-    @RegisterColumnMapper(PermissionSetMapper.class)
-})
+@RegisterColumnMapper(JsonPointerMapper.class)
+@RegisterColumnMapper(PermissionSetMapper.class)
 public interface DatabaseHelperRepository {
 
     @SqlUpdate("delete from access_management;"

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/importer/DefaultPermissionIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/importer/DefaultPermissionIntegrationTest.java
@@ -84,11 +84,11 @@ class DefaultPermissionIntegrationTest extends IntegrationBaseTest {
 
         service.truncateDefaultPermissionsForService(SERVICE_NAME, RESOURCE_TYPE);
 
-        assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME, ATTRIBUTE,
-            ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
+        assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
+            ATTRIBUTE.toString(), ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
 
-        assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME, ATTRIBUTE,
-            SecurityClassification.PUBLIC)).isNull();
+        assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
+            ATTRIBUTE.toString(), SecurityClassification.PUBLIC)).isNull();
     }
 
     @Test
@@ -100,10 +100,10 @@ class DefaultPermissionIntegrationTest extends IntegrationBaseTest {
         service.truncateDefaultPermissionsByResourceDefinition(
             SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME);
 
-        assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME, ATTRIBUTE,
-            ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
+        assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
+            ATTRIBUTE.toString(), ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
 
-        assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME, ATTRIBUTE,
-            SecurityClassification.PUBLIC)).isNull();
+        assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
+            ATTRIBUTE.toString(), SecurityClassification.PUBLIC)).isNull();
     }
 }

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
@@ -21,8 +21,8 @@ public final class TestConstants {
     public static final String RESOURCE_TYPE = "Resource Type";
     public static final String RESOURCE_NAME = "resource";
     public static final SecurityClassification SECURITY_CLASSIFICATION = SecurityClassification.PUBLIC;
-    public static final String ATTRIBUTE = "/test";
     public static final JsonPointer ROOT_ATTRIBUTE = JsonPointer.valueOf("");
+    public static final JsonPointer ATTRIBUTE = JsonPointer.valueOf("/test");
     public static final String ACCESSOR_ID = "a";
     public static final String OTHER_ACCESSOR_ID = "b";
     public static final Set<String> ROLE_NAMES = Stream.of("Role Name").collect(toSet());

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -19,7 +20,7 @@ public final class TestConstants {
     public static final String SERVICE_NAME = "Service";
     public static final String RESOURCE_TYPE = "Resource Type";
     public static final String RESOURCE_NAME = "resource";
-    public static final String SECURITY_CLASSIFICATION = "PUBLIC";
+    public static final SecurityClassification SECURITY_CLASSIFICATION = SecurityClassification.PUBLIC;
     public static final String ATTRIBUTE = "/test";
     public static final JsonPointer ROOT_ATTRIBUTE = JsonPointer.valueOf("");
     public static final String ACCESSOR_ID = "a";


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Uses default constructors in JDBI. It helps hiding raw types from developers.

Next step is to make default constructors on DB model protected.

### Checklist ###

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org) approach and uses one of the following types:
    - build: changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    - ci: changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    - docs: documentation only changes
    - feat: a new feature
    - fix: a bug fix
    - perf: a code change that improves performance
    - refactor: a code change that neither fixes a bug nor adds a feature
    - style: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    - test: adding missing tests or correcting existing tests
- [ ] commit messages are meaningful and follow good commit message guidelines to ease review process
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
