### PR TITLE
Refactor/test constant to enum values

### DIFF
--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/FilterResourceIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/FilterResourceIntegrationTest.java
@@ -24,11 +24,11 @@ import static uk.gov.hmcts.reform.amlib.enums.Permission.CREATE;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.READ;
 import static uk.gov.hmcts.reform.amlib.helpers.DefaultRoleSetupDataFactory.createDefaultPermissionGrant;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
+import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ATTRIBUTE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.CHILD_ATTRIBUTE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.CREATE_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.DATA;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.OTHER_ROLE_NAME;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.PARENT_ATTRIBUTE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.READ_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAMES;
@@ -187,9 +187,9 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
             OTHER_ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
 
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
-            createPermissions(PARENT_ATTRIBUTE, READ_PERMISSION)));
+            createPermissions(ATTRIBUTE, READ_PERMISSION)));
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, OTHER_ROLE_NAME,
-            createPermissions(PARENT_ATTRIBUTE, CREATE_PERMISSION)));
+            createPermissions(ATTRIBUTE, CREATE_PERMISSION)));
 
         FilterResourceResponse result = service.filterResource(ACCESSOR_ID, ROLE_NAMES, createResource(resourceId));
 
@@ -198,14 +198,14 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
             .relationships(ImmutableSet.of(OTHER_ROLE_NAME, ROLE_NAME))
             .data(JsonNodeFactory.instance.objectNode())
             .permissions(ImmutableMap.of(
-                JsonPointer.valueOf(PARENT_ATTRIBUTE), ImmutableSet.of(CREATE, READ)))
+                JsonPointer.valueOf(ATTRIBUTE), ImmutableSet.of(CREATE, READ)))
             .build());
     }
 
     @Test
     void whenExplicitAccessWithSameRelationshipParentChildAttributesWithDiffPermissionsShouldNotMergePermissions() {
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
-            createPermissions(PARENT_ATTRIBUTE, READ_PERMISSION)));
+            createPermissions(ATTRIBUTE, READ_PERMISSION)));
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
             createPermissions(CHILD_ATTRIBUTE, CREATE_PERMISSION)));
 
@@ -217,7 +217,7 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
             .data(JsonNodeFactory.instance.objectNode())
             .permissions(ImmutableMap.of(
                 JsonPointer.valueOf(CHILD_ATTRIBUTE), ImmutableSet.of(CREATE),
-                JsonPointer.valueOf(PARENT_ATTRIBUTE), ImmutableSet.of(READ)))
+                JsonPointer.valueOf(ATTRIBUTE), ImmutableSet.of(READ)))
             .build());
     }
 
@@ -227,7 +227,7 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
             OTHER_ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
 
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
-            createPermissions(PARENT_ATTRIBUTE, READ_PERMISSION)));
+            createPermissions(ATTRIBUTE, READ_PERMISSION)));
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, OTHER_ROLE_NAME,
             createPermissions(CHILD_ATTRIBUTE, CREATE_PERMISSION)));
 
@@ -239,7 +239,7 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
             .data(JsonNodeFactory.instance.objectNode())
             .permissions(ImmutableMap.of(
                 JsonPointer.valueOf(CHILD_ATTRIBUTE), ImmutableSet.of(CREATE, READ),
-                JsonPointer.valueOf(PARENT_ATTRIBUTE), ImmutableSet.of(READ)))
+                JsonPointer.valueOf(ATTRIBUTE), ImmutableSet.of(READ)))
             .build());
     }
 }

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/FilterResourceIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/FilterResourceIntegrationTest.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.reform.amlib.enums.Permission.CREATE;
 import static uk.gov.hmcts.reform.amlib.enums.Permission.READ;
 import static uk.gov.hmcts.reform.amlib.helpers.DefaultRoleSetupDataFactory.createDefaultPermissionGrant;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESS_MANAGEMENT_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.CHILD_ATTRIBUTE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.CREATE_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.DATA;
@@ -33,9 +32,7 @@ import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.PARENT_ATTRIBUTE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.READ_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAMES;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROOT_ATTRIBUTE;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SECURITY_CLASSIFICATION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createGrant;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createGrantForWholeDocument;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createPermissions;
@@ -50,7 +47,7 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
     @BeforeEach
     void setUp() {
         resourceId = UUID.randomUUID().toString();
-        importerService.addRole(ROLE_NAME, ROLE_TYPE, SECURITY_CLASSIFICATION, ACCESS_MANAGEMENT_TYPE);
+        importerService.addRole(ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
     }
 
     @Test
@@ -186,7 +183,8 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
 
     @Test
     void whenExplicitAccessWithDifferentRelationshipSameAttributeAndDifferentPermissionsShouldMergePermissions() {
-        importerService.addRole(OTHER_ROLE_NAME, ROLE_TYPE, SECURITY_CLASSIFICATION, ACCESS_MANAGEMENT_TYPE);
+        importerService.addRole(
+            OTHER_ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
 
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
             createPermissions(PARENT_ATTRIBUTE, READ_PERMISSION)));
@@ -225,7 +223,8 @@ class FilterResourceIntegrationTest extends PreconfiguredIntegrationBaseTest {
 
     @Test
     void whenExplicitAccessWithDifferentRelationshipParentChildAttributeDiffPermissionsShouldMergePermissions() {
-        importerService.addRole(OTHER_ROLE_NAME, ROLE_TYPE, SECURITY_CLASSIFICATION, ACCESS_MANAGEMENT_TYPE);
+        importerService.addRole(
+            OTHER_ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
 
         service.grantExplicitResourceAccess(createGrant(resourceId, ACCESSOR_ID, ROLE_NAME,
             createPermissions(PARENT_ATTRIBUTE, READ_PERMISSION)));

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import uk.gov.hmcts.reform.amlib.AccessManagementService;
 import uk.gov.hmcts.reform.amlib.DefaultRoleSetupImportService;
+import uk.gov.hmcts.reform.amlib.enums.AccessManagementType;
+import uk.gov.hmcts.reform.amlib.enums.AccessType;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
+import uk.gov.hmcts.reform.amlib.enums.RoleType;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 import uk.gov.hmcts.reform.amlib.exceptions.PersistenceException;
 import uk.gov.hmcts.reform.amlib.internal.models.ExplicitAccessRecord;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessGrant;
@@ -21,15 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_IDS;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_TYPE;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESS_MANAGEMENT_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.READ_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAME;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_TYPE;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SECURITY_CLASSIFICATION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SERVICE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createGrant;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createGrantForWholeDocument;
@@ -42,7 +42,7 @@ class GrantAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
     @BeforeEach
     void setUp() {
         resourceId = UUID.randomUUID().toString();
-        importerService.addRole(ROLE_NAME, ROLE_TYPE, SECURITY_CLASSIFICATION, ACCESS_MANAGEMENT_TYPE);
+        importerService.addRole(ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
         MDC.put("caller", "Administrator");
     }
 
@@ -88,12 +88,12 @@ class GrantAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
         ExplicitAccessGrant nonExistingRole = ExplicitAccessGrant.builder()
             .resourceId(resourceId)
             .accessorIds(ACCESSOR_IDS)
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)
             .attributePermissions(multipleAttributePermissions)
-            .securityClassification(SECURITY_CLASSIFICATION)
+            .securityClassification(SecurityClassification.PUBLIC)
             .relationship("NonExistingRoleName")
             .build();
 

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GrantAccessIntegrationTest.java
@@ -77,7 +77,7 @@ class GrantAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
         service.grantExplicitResourceAccess(createGrantForWholeDocument(resourceId, ACCESSOR_IDS, READ_PERMISSION));
 
         assertThat(databaseHelper.findExplicitPermissions(resourceId)).hasSize(2)
-            .extracting(ExplicitAccessRecord::getAccessorId).containsOnly("y", "z");
+            .extracting(ExplicitAccessRecord::getAccessorId).containsOnly(ACCESSOR_IDS.toArray(new String[0]));
     }
 
     @Test

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/RevokeAccessIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/RevokeAccessIntegrationTest.java
@@ -8,6 +8,10 @@ import org.slf4j.MDC;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 import uk.gov.hmcts.reform.amlib.AccessManagementService;
 import uk.gov.hmcts.reform.amlib.DefaultRoleSetupImportService;
+import uk.gov.hmcts.reform.amlib.enums.AccessManagementType;
+import uk.gov.hmcts.reform.amlib.enums.AccessType;
+import uk.gov.hmcts.reform.amlib.enums.RoleType;
+import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 import uk.gov.hmcts.reform.amlib.internal.models.ExplicitAccessRecord;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessGrant;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessMetadata;
@@ -16,14 +20,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_TYPE;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESS_MANAGEMENT_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.READ_PERMISSION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAME;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_TYPE;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SECURITY_CLASSIFICATION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SERVICE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createGrantForWholeDocument;
 import static uk.gov.hmcts.reform.amlib.helpers.TestDataFactory.createMetadata;
@@ -38,7 +38,7 @@ class RevokeAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
     @BeforeEach
     void setUp() {
         resourceId = UUID.randomUUID().toString();
-        importerService.addRole(ROLE_NAME, ROLE_TYPE, SECURITY_CLASSIFICATION, ACCESS_MANAGEMENT_TYPE);
+        importerService.addRole(ROLE_NAME, RoleType.IDAM, SecurityClassification.PUBLIC, AccessManagementType.EXPLICIT);
         MDC.put("caller", "Administrator");
     }
 
@@ -126,12 +126,12 @@ class RevokeAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
         service.grantExplicitResourceAccess(ExplicitAccessGrant.builder()
             .resourceId(resourceId)
             .accessorIds(ImmutableSet.of(ACCESSOR_ID))
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)
             .attributePermissions(createPermissions(attribute, READ_PERMISSION))
-            .securityClassification(SECURITY_CLASSIFICATION)
+            .securityClassification(SecurityClassification.PUBLIC)
             .relationship(ROLE_NAME)
             .build());
     }
@@ -140,12 +140,12 @@ class RevokeAccessIntegrationTest extends PreconfiguredIntegrationBaseTest {
         service.revokeResourceAccess(ExplicitAccessMetadata.builder()
             .resourceId(resourceId)
             .accessorId(ACCESSOR_ID)
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)
             .attribute(JsonPointer.valueOf(attribute))
-            .securityClassification(SECURITY_CLASSIFICATION)
+            .securityClassification(SecurityClassification.PUBLIC)
             .relationship(ROLE_NAME)
             .build());
     }

--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/importer/DefaultPermissionIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/importer/DefaultPermissionIntegrationTest.java
@@ -85,10 +85,10 @@ class DefaultPermissionIntegrationTest extends IntegrationBaseTest {
         service.truncateDefaultPermissionsForService(SERVICE_NAME, RESOURCE_TYPE);
 
         assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
-            ATTRIBUTE.toString(), ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
+            ATTRIBUTE, ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
 
         assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
-            ATTRIBUTE.toString(), SecurityClassification.PUBLIC)).isNull();
+            ATTRIBUTE, SecurityClassification.PUBLIC)).isNull();
     }
 
     @Test
@@ -101,9 +101,9 @@ class DefaultPermissionIntegrationTest extends IntegrationBaseTest {
             SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME);
 
         assertThat(databaseHelper.countDefaultPermissions(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
-            ATTRIBUTE.toString(), ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
+            ATTRIBUTE, ROLE_NAME, Permissions.sumOf(READ_PERMISSION))).isEqualTo(0);
 
         assertThat(databaseHelper.getResourceAttribute(SERVICE_NAME, RESOURCE_TYPE, RESOURCE_NAME,
-            ATTRIBUTE.toString(), SecurityClassification.PUBLIC)).isNull();
+            ATTRIBUTE, SecurityClassification.PUBLIC)).isNull();
     }
 }

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
@@ -14,16 +14,17 @@ import static uk.gov.hmcts.reform.amlib.enums.Permission.UPDATE;
 
 public final class TestConstants {
 
-    public static final String SERVICE_NAME = "Family Public LAw";
+    public static final String SERVICE_NAME = "Family Public Law";
     public static final String RESOURCE_TYPE = "Case";
     public static final String RESOURCE_NAME = "Supervision, EPO care order";
     public static final JsonPointer ROOT_ATTRIBUTE = JsonPointer.valueOf("");
-    public static final JsonPointer ATTRIBUTE = JsonPointer.valueOf("/parents");
-    public static final String PARENT_ATTRIBUTE = "/Parent";
-    public static final String CHILD_ATTRIBUTE = "/Parent/child";
-    public static final String ACCESSOR_ID = "a";
+    public static final String ATTRIBUTE = "/parent";
+    public static final String CHILD_ATTRIBUTE = "/parent/child";
+    public static final String ACCESSOR_ID = "dc84d6b1-70f9-4991-836c-ee30fd1c3914";
     public static final Set<String> ROLE_NAMES = ImmutableSet.of("Solicitor");
-    public static final Set<String> ACCESSOR_IDS = ImmutableSet.of("y", "z");
+    public static final Set<String> ACCESSOR_IDS = ImmutableSet.of(
+        "816127cc-e68e-47ab-b57d-819eca5f0362",
+        "57557976-0683-43bc-a8fb-6817beaf21f4");
     public static final String ROLE_NAME = "Solicitor";
     public static final String OTHER_ROLE_NAME = "Local Authority";
     public static final Set<Permission> EXPLICIT_READ_CREATE_UPDATE_PERMISSIONS = ImmutableSet.of(CREATE, READ, UPDATE);

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestConstants.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableSet;
-import uk.gov.hmcts.reform.amlib.enums.AccessManagementType;
-import uk.gov.hmcts.reform.amlib.enums.AccessType;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
-import uk.gov.hmcts.reform.amlib.enums.RoleType;
-import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 
 import java.util.Set;
 
@@ -18,15 +14,11 @@ import static uk.gov.hmcts.reform.amlib.enums.Permission.UPDATE;
 
 public final class TestConstants {
 
-    public static final AccessType ACCESSOR_TYPE = AccessType.USER;
-    public static final AccessManagementType ACCESS_MANAGEMENT_TYPE = AccessManagementType.EXPLICIT;
-    public static final String SERVICE_NAME = "Service";
-    public static final String RESOURCE_TYPE = "Resource Type";
-    public static final String RESOURCE_NAME = "resource";
-    public static final RoleType ROLE_TYPE = RoleType.IDAM;
-    public static final SecurityClassification SECURITY_CLASSIFICATION = SecurityClassification.PUBLIC;
+    public static final String SERVICE_NAME = "Family Public LAw";
+    public static final String RESOURCE_TYPE = "Case";
+    public static final String RESOURCE_NAME = "Supervision, EPO care order";
     public static final JsonPointer ROOT_ATTRIBUTE = JsonPointer.valueOf("");
-    public static final JsonPointer ATTRIBUTE = JsonPointer.valueOf("/test");
+    public static final JsonPointer ATTRIBUTE = JsonPointer.valueOf("/parents");
     public static final String PARENT_ATTRIBUTE = "/Parent";
     public static final String CHILD_ATTRIBUTE = "/Parent/child";
     public static final String ACCESSOR_ID = "a";

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.amlib.helpers;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import uk.gov.hmcts.reform.amlib.enums.AccessType;
 import uk.gov.hmcts.reform.amlib.enums.Permission;
 import uk.gov.hmcts.reform.amlib.enums.SecurityClassification;
 import uk.gov.hmcts.reform.amlib.models.ExplicitAccessGrant;
@@ -14,12 +15,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_ID;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ACCESSOR_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.DATA;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_NAME;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.RESOURCE_TYPE;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.ROLE_NAME;
-import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SECURITY_CLASSIFICATION;
 import static uk.gov.hmcts.reform.amlib.helpers.TestConstants.SERVICE_NAME;
 
 public final class TestDataFactory {
@@ -59,12 +58,12 @@ public final class TestDataFactory {
         return ExplicitAccessGrant.builder()
             .resourceId(resourceId)
             .accessorIds(ImmutableSet.of(accessorId))
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)
             .attributePermissions(attributePermissions)
-            .securityClassification(SECURITY_CLASSIFICATION)
+            .securityClassification(SecurityClassification.PUBLIC)
             .relationship(relationship)
             .build();
     }
@@ -75,12 +74,12 @@ public final class TestDataFactory {
         return ExplicitAccessGrant.builder()
             .resourceId(resourceId)
             .accessorIds(accessorId)
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)
             .attributePermissions(attributePermissions)
-            .securityClassification(SECURITY_CLASSIFICATION)
+            .securityClassification(SecurityClassification.PUBLIC)
             .relationship(ROLE_NAME)
             .build();
     }
@@ -98,7 +97,7 @@ public final class TestDataFactory {
         return ExplicitAccessMetadata.builder()
             .resourceId(resourceId)
             .accessorId(ACCESSOR_ID)
-            .accessType(ACCESSOR_TYPE)
+            .accessType(AccessType.USER)
             .serviceName(SERVICE_NAME)
             .resourceType(RESOURCE_TYPE)
             .resourceName(RESOURCE_NAME)


### PR DESCRIPTION
Removed enum test constants, replaced in test usage with enum values.

Removed extra unneccesasary test constants.