### PR TITLE
revoke resource access based on relationship method and tests updated

### DIFF
--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
@@ -112,7 +112,8 @@ public class AccessManagementService {
      */
     @AuditLog("explicit access revoked by '{{mdc:caller}}' to resource '{{accessMetadata.resourceId}}' "
         + "defined as '{{accessMetadata.serviceName}}|{{accessMetadata.resourceType}}|{{accessMetadata.resourceName}}' "
-        + "from accessor '{{accessMetadata.accessorId}}': {{accessMetadata.attribute}}")
+        + "from accessor '{{accessMetadata.accessorId}}': {{accessMetadata.attribute}} "
+        + "with relationship {{accessMetadata.relationship}}")
     public void revokeResourceAccess(@NotNull @Valid ExplicitAccessMetadata accessMetadata) {
         jdbi.useExtension(AccessManagementRepository.class,
             dao -> dao.removeAccessManagementRecord(accessMetadata));

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/internal/repositories/AccessManagementRepository.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/internal/repositories/AccessManagementRepository.java
@@ -34,8 +34,9 @@ public interface AccessManagementRepository {
         + "and access_management.service_name = :serviceName "
         + "and access_management.resource_type = :resourceType "
         + "and access_management.resource_name = :resourceName "
+        + "and (:relationship is null or access_management.relationship = :relationship) "
         + "and access_management.attribute = :attributeAsString "
-        + "or access_management.attribute like concat(:attributeAsString, '/', '%')")
+        + "or access_management.attribute like concat(:attributeAsString, '/', '%') ")
     void removeAccessManagementRecord(@BindBean ExplicitAccessMetadata explicitAccessMetadata);
 
     @SqlQuery("select * from access_management where accessor_id=? and resource_id=?")

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessMetadata.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/models/ExplicitAccessMetadata.java
@@ -28,6 +28,7 @@ public final class ExplicitAccessMetadata {
     private final JsonPointer attribute;
     @NotNull
     private final SecurityClassification securityClassification;
+    private final String relationship;
 
     public String getAttributeAsString() {
         return getAttribute().toString();

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/AccessManagementServiceValidationTest.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/AccessManagementServiceValidationTest.java
@@ -51,7 +51,7 @@ class AccessManagementServiceValidationTest {
                 "accessMetadata.resourceName - must not be blank",
                 "accessMetadata.attribute - must not be null",
                 "accessMetadata.securityClassification - must not be null",
-                "accessMetadata.relationship - must not be blank"
+                "accessMetadata.relationship - must not be null"
             ));
     }
 

--- a/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
+++ b/am-lib/src/test/java/uk/gov/hmcts/reform/amlib/helpers/TestDataFactory.java
@@ -94,6 +94,7 @@ public final class TestDataFactory {
             .resourceName(RESOURCE_NAME)
             .attribute(JsonPointer.valueOf(""))
             .securityClassification(SecurityClassification.PUBLIC)
+            .relationship(ROLE_NAME)
             .build();
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-249

Updating current revoke method to take relationship into account and updated test suite.