### PR TITLE
fix: make retrieving resource definitions with root create permissions use EXPLICIT and ROLE_BASED access type

### DIFF
--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.amlib.models.FilteredResourceEnvelope;
 import uk.gov.hmcts.reform.amlib.models.Resource;
 import uk.gov.hmcts.reform.amlib.models.ResourceDefinition;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,7 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static uk.gov.hmcts.reform.amlib.enums.AccessType.ROLE_BASED;
 
 @SuppressWarnings("PMD.ExcessiveImports")
 public class AccessManagementService {
@@ -180,7 +182,7 @@ public class AccessManagementService {
                 return null;
             }
 
-            accessType = AccessType.ROLE_BASED;
+            accessType = ROLE_BASED;
 
         } else {
             List<Map<JsonPointer, Set<Permission>>> permissionsForRelationships = explicitAccess.stream()
@@ -220,7 +222,7 @@ public class AccessManagementService {
         }
 
         return jdbi.withExtension(AccessManagementRepository.class,
-            dao -> dao.getRoles(userRoles, AccessType.ROLE_BASED).stream()
+            dao -> dao.getRoles(userRoles, Collections.singleton(ROLE_BASED)).stream()
                 .map(Role::getRoleName)
                 .collect(toSet()));
     }
@@ -269,7 +271,7 @@ public class AccessManagementService {
     @AuditLog("returned resources that user with roles '{{userRoles}}' has create permission to: {{result}}")
     public Set<ResourceDefinition> getResourceDefinitionsWithRootCreatePermission(@NotEmpty Set<@NotBlank String> userRoles) {
         Integer maxSecurityClassificationForRole = jdbi.withExtension(AccessManagementRepository.class, dao ->
-            dao.getRoles(userRoles, AccessType.ROLE_BASED)
+            dao.getRoles(userRoles, Collections.singleton(ROLE_BASED))
                 .stream()
                 .mapToInt(role -> role.getSecurityClassification().getHierarchy())
                 .max()

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/AccessManagementService.java
@@ -32,6 +32,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import javax.sql.DataSource;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -42,6 +44,7 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static uk.gov.hmcts.reform.amlib.enums.AccessType.EXPLICIT;
 import static uk.gov.hmcts.reform.amlib.enums.AccessType.ROLE_BASED;
 
 @SuppressWarnings("PMD.ExcessiveImports")
@@ -193,7 +196,7 @@ public class AccessManagementService {
                 .collect(toList());
 
             attributePermissions = permissionsService.merge(permissionsForRelationships);
-            accessType = AccessType.EXPLICIT;
+            accessType = EXPLICIT;
         }
 
         JsonNode filteredJson = filterService.filterJson(resource.getData(), attributePermissions);
@@ -271,7 +274,7 @@ public class AccessManagementService {
     @AuditLog("returned resources that user with roles '{{userRoles}}' has create permission to: {{result}}")
     public Set<ResourceDefinition> getResourceDefinitionsWithRootCreatePermission(@NotEmpty Set<@NotBlank String> userRoles) {
         Integer maxSecurityClassificationForRole = jdbi.withExtension(AccessManagementRepository.class, dao ->
-            dao.getRoles(userRoles, Collections.singleton(ROLE_BASED))
+            dao.getRoles(userRoles, Stream.of(EXPLICIT, ROLE_BASED).collect(toSet()))
                 .stream()
                 .mapToInt(role -> role.getSecurityClassification().getHierarchy())
                 .max()

--- a/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/internal/repositories/AccessManagementRepository.java
+++ b/am-lib/src/main/java/uk/gov/hmcts/reform/amlib/internal/repositories/AccessManagementRepository.java
@@ -49,9 +49,9 @@ public interface AccessManagementRepository {
     @RegisterConstructorMapper(RoleBasedAccessRecord.class)
     List<RoleBasedAccessRecord> getRolePermissions(@BindBean ResourceDefinition resourceDefinition, String roleName);
 
-    @SqlQuery("select * from roles where role_name in (<userRoles>) and access_type = cast(:accessType as access_type)")
+    @SqlQuery("select * from roles where role_name in (<userRoles>) and cast(access_type as text) in (<accessTypes>)")
     @RegisterConstructorMapper(Role.class)
-    Set<Role> getRoles(@BindList Set<String> userRoles, AccessType accessType);
+    Set<Role> getRoles(@BindList Set<String> userRoles, @BindList Set<AccessType> accessTypes);
 
     @SqlQuery("select distinct default_perms.service_name, default_perms.resource_type, default_perms.resource_name from default_permissions_for_roles default_perms"
         + " join resource_attributes as resource on default_perms.service_name = resource.service_name and default_perms.resource_type = resource.resource_type and default_perms.resource_name = resource.resource_name"


### PR DESCRIPTION
getRoles sql now returns roles for Set<AccessType> meaning it can still provide filtering, as well as retrieving all roles.

getResourceDefinitionWithRootCreatePermission now uses:
`dao.getRoles(userRoles, Stream.of(EXPLICIT, ROLE_BASED).collect(toSet()))`