### PR TITLE
ci: Travis configuration update from oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
### JIRA link (if applicable) ###  
https://tools.hmcts.net/jira/browse/AM-279

### Change description ###
Travis build for am-lib is failing as we observed error in the JDK version. As per the suggestions from **#cloud-native** channel team, we decided to change the JDK from oraclejdk to openjdk
