### PR TITLE
fix: test case failure

### DIFF
--- a/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GetResourceDefinitionsWithCreatePermissionIntegrationTest.java
+++ b/am-lib/src/test/java/integration/uk/gov/hmcts/reform/amlib/GetResourceDefinitionsWithCreatePermissionIntegrationTest.java
@@ -137,8 +137,7 @@ class GetResourceDefinitionsWithCreatePermissionIntegrationTest extends Preconfi
 
     @Test
     void whenMultipleRoleBasedAccessRecordsShouldOnlyReturnDefinitionsAllowedByRoleSecurityClassification() {
-        String rolePublic = "RoleWithOnlyPublic";
-
+        String rolePublic = UUID.randomUUID().toString();
         importerService.addRole(rolePublic, IDAM, PUBLIC, ROLE_BASED);
 
         grantRootPermission(rolePublic, resourceDefinition, CREATE, PUBLIC);
@@ -152,8 +151,7 @@ class GetResourceDefinitionsWithCreatePermissionIntegrationTest extends Preconfi
 
     @Test
     void whenRoleDoesNotHaveHighEnoughSecurityClassificationShouldReturnEmptyList() {
-        String rolePublic = "RoleWithOnlyPublic";
-
+        String rolePublic = UUID.randomUUID().toString();
         importerService.addRole(rolePublic, IDAM, PUBLIC, ROLE_BASED);
 
         grantRootPermission(rolePublic, resourceDefinition, CREATE, RESTRICTED);
@@ -166,8 +164,8 @@ class GetResourceDefinitionsWithCreatePermissionIntegrationTest extends Preconfi
 
     @Test
     void whenTwoRolesWithDifferentSecurityClassificationShouldUseTheHighestSecurityClassificationToFilter() {
-        String rolePublic = "RoleWithOnlyPublic";
-        String rolePrivate = "RoleWithPrivate";
+        String rolePublic = UUID.randomUUID().toString();
+        String rolePrivate = UUID.randomUUID().toString();
 
         importerService.addRole(rolePublic, IDAM, PUBLIC, ROLE_BASED);
         importerService.addRole(rolePrivate, IDAM, PRIVATE, ROLE_BASED);


### PR DESCRIPTION
### Change description ###
Some tests were not using randomised data which lead to db collisions between tests (assertions were getting more data than expected). Randomised role names introduced to avoid collisions. 
