### PR TITLE
chore: cut release script fix, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [0.8.0](https://github.com/hmcts/am-lib/compare/0.7.0...0.8.0) (2019-05-21)
+
+
+### Bug Fixes
+
+* AM-279 - Modified the jdk from oraclejdk to openjdk ([#158](https://github.com/hmcts/am-lib/issues/158)) ([2cdc9d7](https://github.com/hmcts/am-lib/commit/2cdc9d7))
+
+
+### Features
+
+* Filtering uses security classification(AM-77) ([#164](https://github.com/hmcts/am-lib/issues/164)) ([1dae741](https://github.com/hmcts/am-lib/commit/1dae741))
+* retrieve security classifications of attributes for a role ([#142](https://github.com/hmcts/am-lib/issues/142)) ([1ad4a29](https://github.com/hmcts/am-lib/commit/1ad4a29))
+
+
+
 # [0.7.0](https://github.com/hmcts/am-lib/compare/0.6.0...0.7.0) (2019-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.9.0](https://github.com/hmcts/am-lib/compare/0.8.0...0.9.0) (2019-05-21)
+
+
+### Features
+
+* enhanced filtering logic for security classification inheritance ([#180](https://github.com/hmcts/am-lib/issues/180)) ([279a889](https://github.com/hmcts/am-lib/commit/279a889))
+
+
+
 # [0.8.0](https://github.com/hmcts/am-lib/compare/0.7.0...0.8.0) (2019-05-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.9.1](https://github.com/hmcts/am-lib/compare/0.9.0...0.9.1) (2019-05-21)
+
+
+
 # [0.9.0](https://github.com/hmcts/am-lib/compare/0.8.0...0.9.0) (2019-05-21)
 
 

--- a/am-lib/bin/cut-release.sh
+++ b/am-lib/bin/cut-release.sh
@@ -74,7 +74,11 @@ function change_version() {
   local current_version=${1}
   local next_version=${2}
 
-  sed -i '' "s|version=${current_version}|version=${next_version}|" ${dir}/../gradle.properties
+  #for mas os
+  #sed -i '' "s|version=${current_version}|version=${next_version}|" ${dir}/../gradle.properties
+
+  #for windows
+  sed -i "s/version=${current_version}/version=${next_version}/" ${dir}/../gradle.properties
 }
 
 function update_changelog() {

--- a/am-lib/gradle.properties
+++ b/am-lib/gradle.properties
@@ -1,1 +1,1 @@
-version=0.7.0
+version=0.8.0

--- a/am-lib/gradle.properties
+++ b/am-lib/gradle.properties
@@ -1,1 +1,1 @@
-version=0.8.0
+version=0.9.0

--- a/am-lib/gradle.properties
+++ b/am-lib/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.0
+version=0.9.1


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/AM-246

### Change description ###
cut-release.sh was not working and release creation in github was failing; corrected to be able to run it from windows machines