### PR TITLE
chore: Log level changed to see gatling logs in Jenkins

### DIFF
--- a/src/gatling/conf/logback.xml
+++ b/src/gatling/conf/logback.xml
@@ -12,9 +12,7 @@
 	<!-- 	<logger name="io.gatling.http.ahc" level="TRACE" /> -->
 	<!--   <logger name="io.gatling.http.response" level="TRACE" /> -->
 	<!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
-	 	<logger name="io.gatling.http.ahc" level="DEBUG" /> 
-	    <logger name="io.gatling.http.response" level="DEBUG" />  
-
+    <logger name="io.gatling.http.engine.response" level="DEBUG" />
 	<root level="WARN">
 		<appender-ref ref="CONSOLE" />
 	</root>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/AM-303

### Change description ###
Log file changed as suggested by cloud native team   
