### PR TITLE
feat: CCD to AM migration scripts (AM-266)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ classes/
 /src/gatling/bin/
 /src/gatling/lib/
 /src/gatling/target/
+
+# CCD migration data
+/migration/ccd.csv

--- a/migration/ccd-to-am-migration-init.sql
+++ b/migration/ccd-to-am-migration-init.sql
@@ -1,0 +1,77 @@
+
+BEGIN;
+
+CREATE TEMP TABLE stage
+(
+    case_data_id VARCHAR, case_type_id VARCHAR,
+    user_id VARCHAR, case_role VARCHAR
+)
+ON COMMIT DROP;
+
+\COPY stage FROM 'ccd.csv' DELIMITER ',' CSV HEADER;
+
+WITH ins_services AS
+(
+    INSERT INTO services
+        SELECT case_type_id AS service_name,
+            concat(case_type_id, ' sample description') AS service_description
+        FROM stage
+        GROUP BY service_name
+    EXCEPT
+        SELECT * FROM services
+    RETURNING service_name
+)
+SELECT COUNT(*) AS "services inserts" FROM ins_services;
+
+WITH ins_resources AS
+(
+    INSERT INTO resources
+        SELECT case_type_id AS service_name, 'CASE' AS resource_type,
+            case_type_id AS resource_name
+        FROM stage
+        GROUP BY resource_name
+    EXCEPT
+        SELECT * FROM resources
+    RETURNING resource_name
+)
+SELECT COUNT(*) AS "resources inserts" FROM ins_resources;
+
+WITH ins_resource_attributes AS
+(
+    INSERT INTO resource_attributes
+        SELECT service_name, resource_type, resource_name, '' AS "attribute",
+            'PUBLIC' as default_security_classification
+        FROM resources
+    EXCEPT
+        SELECT * FROM resource_attributes
+    RETURNING resource_name
+)
+SELECT COUNT(*) AS "resource_attributes inserts" FROM ins_resource_attributes;
+
+WITH ins_roles AS
+(
+    INSERT INTO roles
+        SELECT case_role AS role_name, 'RESOURCE' AS role_type,
+            'PUBLIC' AS security_classification, 'ROLE_BASED' AS access_type
+        FROM stage
+        GROUP BY role_name
+    EXCEPT
+        SELECT * FROM roles
+    RETURNING role_name
+)
+SELECT COUNT(*) AS "roles inserts" FROM ins_roles;
+
+WITH ins_default_permissions_for_roles AS
+(
+    INSERT INTO default_permissions_for_roles
+        SELECT re.service_name AS service_name, re.resource_type AS resource_type,
+            re.resource_name AS resource_name, '' AS "attribute",
+            ro.role_name AS role_name, '2' AS permissions
+        FROM resources AS re, roles AS ro
+    EXCEPT
+        SELECT * FROM default_permissions_for_roles
+    RETURNING resource_name
+)
+SELECT COUNT(*) AS "default_permissions_for_roles inserts" FROM ins_default_permissions_for_roles;
+
+COMMIT;

--- a/migration/ccd-to-am-migration-main.sql
+++ b/migration/ccd-to-am-migration-main.sql
@@ -8,7 +8,6 @@ CREATE TEMP TABLE stage
 )
 ON COMMIT DROP;
 
-ALTER TABLE access_management DROP CONSTRAINT "AccessManagement_pkey";
 ALTER TABLE access_management DROP CONSTRAINT access_management_unique;
 ALTER TABLE access_management DROP CONSTRAINT access_management_resources_fkey;
 ALTER TABLE access_management DROP CONSTRAINT relationship_fkey;
@@ -42,8 +41,6 @@ WITH ins_access_management AS
 )
 SELECT COUNT(*) AS "access_management inserts" FROM ins_access_management;
 
-ALTER TABLE access_management ADD CONSTRAINT "AccessManagement_pkey"
-    PRIMARY KEY (access_management_id);
 ALTER TABLE access_management ADD CONSTRAINT access_management_unique
     UNIQUE (resource_id, accessor_id, accessor_type, "attribute", resource_type,
     service_name, resource_name, relationship);

--- a/migration/ccd-to-am-migration-main.sql
+++ b/migration/ccd-to-am-migration-main.sql
@@ -1,0 +1,57 @@
+
+BEGIN;
+
+CREATE TEMP TABLE stage
+(
+    case_data_id VARCHAR, case_type_id VARCHAR,
+    user_id VARCHAR, case_role VARCHAR
+)
+ON COMMIT DROP;
+
+ALTER TABLE access_management DROP CONSTRAINT "AccessManagement_pkey";
+ALTER TABLE access_management DROP CONSTRAINT access_management_unique;
+ALTER TABLE access_management DROP CONSTRAINT access_management_resources_fkey;
+ALTER TABLE access_management DROP CONSTRAINT relationship_fkey;
+
+\COPY stage FROM 'ccd.csv' DELIMITER ',' CSV HEADER;
+
+SELECT COUNT(*) AS "columns to migrate" FROM stage;
+
+WITH ins_access_management AS
+(
+    INSERT INTO access_management (resource_id, accessor_type, accessor_id,
+            "attribute", permissions, service_name, resource_name,
+            resource_type, relationship)
+        SELECT s.case_data_id AS resource_id, 'USER' AS accessor_type,
+            s.user_id AS accessor_id, ra."attribute" AS "attribute",
+            dp.permissions AS permissions, re.service_name AS service_name,
+            s.case_type_id AS resource_name, re.resource_type AS resource_type,
+            s.case_role AS relationship
+        FROM stage AS s, resource_attributes AS ra,
+            default_permissions_for_roles AS dp, resources AS re
+        WHERE ra.resource_name = s.case_type_id
+        AND dp.resource_name = s.case_type_id
+        AND re.resource_name = s.case_type_id
+        AND s.case_role IN (SELECT role_name FROM roles)
+    EXCEPT
+        SELECT resource_id, accessor_type, accessor_id, "attribute",
+            permissions, service_name, resource_name, resource_type,
+            relationship
+        FROM access_management
+    RETURNING resource_id
+)
+SELECT COUNT(*) AS "access_management inserts" FROM ins_access_management;
+
+ALTER TABLE access_management ADD CONSTRAINT "AccessManagement_pkey"
+    PRIMARY KEY (access_management_id);
+ALTER TABLE access_management ADD CONSTRAINT access_management_unique
+    UNIQUE (resource_id, accessor_id, accessor_type, "attribute", resource_type,
+    service_name, resource_name, relationship);
+ALTER TABLE access_management ADD CONSTRAINT access_management_resources_fkey
+    FOREIGN KEY (service_name, resource_type, resource_name)
+    REFERENCES resources(service_name, resource_type, resource_name);
+ALTER TABLE access_management ADD CONSTRAINT relationship_fkey
+    FOREIGN KEY (relationship)
+    REFERENCES roles(role_name);
+
+COMMIT;

--- a/migration/ccd-to-am-migration-runner.sh
+++ b/migration/ccd-to-am-migration-runner.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+echo
+set -e
+set -u
+
+DB="am"
+USER="amuser"
+INIT_SQL="./ccd-to-am-migration-init.sql"
+MAIN_SQL="./ccd-to-am-migration-main.sql"
+
+psql \
+    -X \
+    -q \
+    -U $USER \
+    -f $INIT_SQL \
+    --set AUTOCOMMIT=off \
+    --set ON_ERROR_STOP=off \
+    $DB
+
+psql \
+    -X \
+    -q \
+    -U $USER \
+    -f $MAIN_SQL \
+    --set AUTOCOMMIT=off \
+    --set ON_ERROR_STOP=off \
+    $DB
+
+echo "migration successful"
+exit 0

--- a/migration/ccd-to-am-migration-runner.sh
+++ b/migration/ccd-to-am-migration-runner.sh
@@ -4,14 +4,22 @@ echo
 set -e
 set -u
 
-DB="am"
-USER="amuser"
 INIT_SQL="./ccd-to-am-migration-init.sql"
 MAIN_SQL="./ccd-to-am-migration-main.sql"
+
+echo "* CCD to AM migration..."
+echo
+read -p "* AM DB hostname: " HOST
+read -p "* AM DB port: " PORT
+read -p "* AM DB name: " DB
+read -p "* AM DB username: " USER
+echo
 
 psql \
     -X \
     -q \
+    -h $HOST \
+    -p $PORT \
     -U $USER \
     -f $INIT_SQL \
     --set AUTOCOMMIT=off \
@@ -21,11 +29,14 @@ psql \
 psql \
     -X \
     -q \
+    -h $HOST \
+    -p $PORT \
     -U $USER \
     -f $MAIN_SQL \
     --set AUTOCOMMIT=off \
     --set ON_ERROR_STOP=off \
     $DB
 
-echo "migration successful"
+echo "* Migration finished"
+echo
 exit 0


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/AM-266


### Change description ###
Added scripts to migrate CCD data to AM database. One script for initial population of supporting AM tables (to be removed later as CCD will populate these fields themselves) and another script for the main data migration to the access_management table.
