### PR TITLE
disable zap security scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -75,19 +75,19 @@ withNightlyPipeline(type, product, component) {
   loadVaultSecrets(secrets)
   enableMutationTest()
   enablePerformanceTest()
-  enableSecurityScan()
+  //enableSecurityScan()
   enableSlackNotifications('#am-master-builds')
 
   after('checkout') {
     sh '''
       set -e
-  
+
       echo "7be85238cbbb957ab25de52b60279d40ba40d3faa72eeb2cb9fa77d6d92381e5 git-lfs-v2.7.1.tar.gz" > git-lfs-v2.7.1.checksum.txt
       curl --silent --location https://github.com/git-lfs/git-lfs/releases/download/v2.7.1/git-lfs-linux-amd64-v2.7.1.tar.gz > git-lfs-v2.7.1.tar.gz
       sha256sum --check --status git-lfs-v2.7.1.checksum.txt
-      
+
       tar xz -f git-lfs-v2.7.1.tar.gz -C bin/ git-lfs
-    
+
       export PATH=$PATH:./bin
       git lfs install --local && git lfs pull
     '''


### PR DESCRIPTION
Security scan is failing in nightly build with error - 
TypeError: string indices must be integers

This seems to be issue with zap scripts under infrastructure.  This needs  analysis from the  devops team